### PR TITLE
 BUG FIX

### DIFF
--- a/examples/pong/pong.go
+++ b/examples/pong/pong.go
@@ -18,13 +18,17 @@ type PongClass struct {
 }
 
 // Xready is called as soon as the node enters the scene.
-func (p *PongClass) Xready() {
+func (p *PongClass) X_ready() {
 	godot.Log.Println("Pong is ready!")
 }
 
-func (p *PongClass) Xprocess(delta float64) {
+func (p *PongClass) X_process(delta float64) {
 	godot.Log.Println("Processing in pong.go!")
 	godot.Log.Println("  Delta:", delta)
+}
+
+func (p *PongClass) CustomFunc(myPhrase string) {
+	godot.Log.Println(myPhrase)
 }
 
 // The "init()" function is a special Go function that will be called when this library

--- a/godot/variant.go
+++ b/godot/variant.go
@@ -74,27 +74,26 @@ func variantAsString(variant *C.godot_variant) string {
 
 /*
 TODO:
-godot_vector2 GDAPI godot_variant_as_vector2(const godot_variant *p_self);
-godot_rect2 GDAPI godot_variant_as_rect2(const godot_variant *p_self);
-godot_vector3 GDAPI godot_variant_as_vector3(const godot_variant *p_self);
-godot_transform2d GDAPI godot_variant_as_transform2d(const godot_variant *p_self);
-godot_plane GDAPI godot_variant_as_plane(const godot_variant *p_self);
-godot_quat GDAPI godot_variant_as_quat(const godot_variant *p_self);
-godot_rect3 GDAPI godot_variant_as_rect3(const godot_variant *p_self);
-godot_basis GDAPI godot_variant_as_basis(const godot_variant *p_self);
-godot_transform GDAPI godot_variant_as_transform(const godot_variant *p_self);
-godot_color GDAPI godot_variant_as_color(const godot_variant *p_self);
-godot_node_path GDAPI godot_variant_as_node_path(const godot_variant *p_self);
-godot_rid GDAPI godot_variant_as_rid(const godot_variant *p_self);
-godot_object GDAPI *godot_variant_as_object(const godot_variant *p_self);
-godot_dictionary GDAPI godot_variant_as_dictionary(const godot_variant *p_self);
 godot_array GDAPI godot_variant_as_array(const godot_variant *p_self);
+godot_basis GDAPI godot_variant_as_basis(const godot_variant *p_self);
+godot_color GDAPI godot_variant_as_color(const godot_variant *p_self);
+godot_dictionary GDAPI godot_variant_as_dictionary(const godot_variant *p_self);
+godot_node_path GDAPI godot_variant_as_node_path(const godot_variant *p_self);
+godot_object GDAPI *godot_variant_as_object(const godot_variant *p_self);
+godot_plane GDAPI godot_variant_as_plane(const godot_variant *p_self);
 godot_pool_byte_array GDAPI godot_variant_as_pool_byte_array(const godot_variant *p_self);
+godot_pool_color_array GDAPI godot_variant_as_pool_color_array(const godot_variant *p_self);
 godot_pool_int_array GDAPI godot_variant_as_pool_int_array(const godot_variant *p_self);
 godot_pool_real_array GDAPI godot_variant_as_pool_real_array(const godot_variant *p_self);
 godot_pool_string_array GDAPI godot_variant_as_pool_string_array(const godot_variant *p_self);
 godot_pool_vector2_array GDAPI godot_variant_as_pool_vector2_array(const godot_variant *p_self);
 godot_pool_vector3_array GDAPI godot_variant_as_pool_vector3_array(const godot_variant *p_self);
-godot_pool_color_array GDAPI godot_variant_as_pool_color_array(const godot_variant *p_self);
-
+godot_quat GDAPI godot_variant_as_quat(const godot_variant *p_self);
+godot_rect2 GDAPI godot_variant_as_rect2(const godot_variant *p_self);
+godot_rect3 GDAPI godot_variant_as_rect3(const godot_variant *p_self);
+godot_rid GDAPI godot_variant_as_rid(const godot_variant *p_self);
+godot_transform GDAPI godot_variant_as_transform(const godot_variant *p_self);
+godot_transform2d GDAPI godot_variant_as_transform2d(const godot_variant *p_self);
+godot_vector2 GDAPI godot_variant_as_vector2(const godot_variant *p_self);
+godot_vector3 GDAPI godot_variant_as_vector3(const godot_variant *p_self);
 */


### PR DESCRIPTION
Fixed the args loop when calling go_method_func. It was skipping the
first argument.
Added an example custom method to the PongClass called CustomFunc that can be called
from GDScript.
Replaced native GD _ translator "X" to "X_" as a way to mitigate issues if a function started with "X", and better identify the native GD required functions.